### PR TITLE
Add participant exclusions summary

### DIFF
--- a/notebooks/summaries/exclusions.Rmd
+++ b/notebooks/summaries/exclusions.Rmd
@@ -20,17 +20,21 @@ make_pretty_df <- function(df) {
 }
 ```
 
-## Participants we are excludinbg from analysis
+## Participants we are excluding from analysis
 
 ### How many participants are excluded from the analysis phase?
 
-A total of **2 participants** of 49 eligible (completed task) are being fully excluded from analysis.
+A total of **3 participants** of 49 eligible (completed task) are being fully excluded from analysis.
 
 ### Which participants are excluded and why?
 
-Both CSN011 and CSN027 are excluded from the analysis due to poor calibration
-of eye-tracking quality, as determined by the change in validation metric `avg_error`
-between pre- and post-task validation phases. Our upper bound of average error that 
-is _good enough_ to be considered for analysis is 2.5 degrees. For a participant to
-be included, the average error must be within 2.5 degress at _both_ validation and
-re-validation.
+The following participants are excluded:
+
+- CSN002
+- CSN011
+- CSN027
+
+These three participants are excluded due to poor eye-tracker calibration quality,
+as determined by the validation metric `avg_error` at pre- and post-task validation phases.
+A participant's eye-tracking quality is _good enough_ for analysis if the average error is
+less than 2.5 degrees at _both_ validation and re-validation phases.

--- a/notebooks/summaries/exclusions.Rmd
+++ b/notebooks/summaries/exclusions.Rmd
@@ -1,0 +1,36 @@
+---
+title: "Summary Notebook: Exclusions"
+author: "Ari Dyckovsky"
+---
+
+```{r, notebook-options, include=FALSE}
+knitr::opts_chunk$set(
+  warning = FALSE,
+  strip.white = TRUE,
+  highlight = TRUE,
+  warning = FALSE,
+  message = FALSE
+)
+make_pretty_df <- function(df) {
+  if (isTRUE(getOption("knitr.in.progress"))) {
+    knitr::kable(df, "simple", format.args = list(big.mark = ",", scientific = FALSE))
+  } else {
+    df
+  }
+}
+```
+
+## Participants we are excludinbg from analysis
+
+### How many participants are excluded from the analysis phase?
+
+A total of **2 participants** of 49 eligible (completed task) are being fully excluded from analysis.
+
+### Which participants are excluded and why?
+
+Both CSN011 and CSN027 are excluded from the analysis due to poor calibration
+of eye-tracking quality, as determined by the change in validation metric `avg_error`
+between pre- and post-task validation phases. Our upper bound of average error that 
+is _good enough_ to be considered for analysis is 2.5 degrees. For a participant to
+be included, the average error must be within 2.5 degress at _both_ validation and
+re-validation.

--- a/notebooks/summaries/exclusions.md
+++ b/notebooks/summaries/exclusions.md
@@ -1,0 +1,27 @@
+Summary Notebook: Exclusions
+================
+Ari Dyckovsky
+
+  - [Participants we are excludinbg from
+    analysis](#participants-we-are-excludinbg-from-analysis)
+      - [How many participants are excluded from the analysis
+        phase?](#how-many-participants-are-excluded-from-the-analysis-phase)
+      - [Which participants are excluded and
+        why?](#which-participants-are-excluded-and-why)
+
+## Participants we are excludinbg from analysis
+
+### How many participants are excluded from the analysis phase?
+
+A total of **2 participants** of 49 eligible (completed task) are being
+fully excluded from analysis.
+
+### Which participants are excluded and why?
+
+Both CSN011 and CSN027 are excluded from the analysis due to poor
+calibration of eye-tracking quality, as determined by the change in
+validation metric `avg_error` between pre- and post-task validation
+phases. Our upper bound of average error that is *good enough* to be
+considered for analysis is 2.5 degrees. For a participant to be
+included, the average error must be within 2.5 degress at *both*
+validation and re-validation.

--- a/notebooks/summaries/exclusions.md
+++ b/notebooks/summaries/exclusions.md
@@ -2,26 +2,30 @@ Summary Notebook: Exclusions
 ================
 Ari Dyckovsky
 
-  - [Participants we are excludinbg from
-    analysis](#participants-we-are-excludinbg-from-analysis)
+  - [Participants we are excluding from
+    analysis](#participants-we-are-excluding-from-analysis)
       - [How many participants are excluded from the analysis
         phase?](#how-many-participants-are-excluded-from-the-analysis-phase)
       - [Which participants are excluded and
         why?](#which-participants-are-excluded-and-why)
 
-## Participants we are excludinbg from analysis
+## Participants we are excluding from analysis
 
 ### How many participants are excluded from the analysis phase?
 
-A total of **2 participants** of 49 eligible (completed task) are being
+A total of **3 participants** of 49 eligible (completed task) are being
 fully excluded from analysis.
 
 ### Which participants are excluded and why?
 
-Both CSN011 and CSN027 are excluded from the analysis due to poor
-calibration of eye-tracking quality, as determined by the change in
-validation metric `avg_error` between pre- and post-task validation
-phases. Our upper bound of average error that is *good enough* to be
-considered for analysis is 2.5 degrees. For a participant to be
-included, the average error must be within 2.5 degress at *both*
-validation and re-validation.
+The following participants are excluded:
+
+  - CSN002
+  - CSN011
+  - CSN027
+
+These three participants are excluded due to poor eye-tracker
+calibration quality, as determined by the validation metric `avg_error`
+at pre- and post-task validation phases. A participant’s eye-tracking
+quality is *good enough* for analysis if the average error is less than
+2.5 degrees at *both* validation and re-validation phases.


### PR DESCRIPTION
# Add participant exclusions summary

## Description

Created and populated an RMarkdown summary notebook for participant exclusions, as well as a knitted Markdown copy for GitHub-flavored Markdown presentation.

Addresses #12

## Type of change

- [x] New feature (non-breaking change which adds functionality)
