### PR TITLE
Add participant incompletes summary

### DIFF
--- a/notebooks/summaries/incompletes.Rmd
+++ b/notebooks/summaries/incompletes.Rmd
@@ -25,6 +25,30 @@ make_pretty_df <- function(df) {
 
 ### How many participants were incomplete?
 
+A total of **8 participants** of 57 recruited did _not complete_ the task.
+
 ### What were the reasons participants did not complete the task?
 
+The reasons participants did not complete the task are briefly described
+in the following list by participant identifier:
+
+- CSN003 had calibration issues (wore glasses)
+- CSN014 had calibration issues (too much eye makeup)
+- CSN024 stopped early due to illness
+- CSN028 had calibration issues (difficult eye shape)
+- CSN031 (no notes; Experimenter: LA)
+- CSN046 stopped early due to graphic images
+- CSN050 had calibration issues (wore contacts)
+
+Currently, we do not have enough information on:
+
+- CSN013 may have completed the task
+
 ### Can we group the incompletes by common reasons?
+
+Yes, the incompletes can be grouped by two common reasons:
+
+1. Calibration difficulty (i.e., corrective lenses or make-up) applies to 4 of 8 incompletes
+2. Deciding to stop the task early (i.e., illness or difficulty with image content) applies to 2 of 8 incompletes
+
+Otherwise, 2 of 8 listed incompletes (CSN013, CSN031) have unknown reasons.

--- a/notebooks/summaries/incompletes.Rmd
+++ b/notebooks/summaries/incompletes.Rmd
@@ -25,7 +25,7 @@ make_pretty_df <- function(df) {
 
 ### How many participants were incomplete?
 
-A total of **8 participants** of 57 recruited did _not complete_ the task.
+A total of **7 participants** of 57 recruited did _not complete_ the task.
 
 ### What were the reasons participants did not complete the task?
 
@@ -36,19 +36,13 @@ in the following list by participant identifier:
 - CSN014 had calibration issues (too much eye makeup)
 - CSN024 stopped early due to illness
 - CSN028 had calibration issues (difficult eye shape)
-- CSN031 (no notes; Experimenter: LA)
+- CSN031 had calibration issues (wore glasses)
 - CSN046 stopped early due to graphic images
 - CSN050 had calibration issues (wore contacts)
-
-Currently, we do not have enough information on:
-
-- CSN013 may have completed the task
 
 ### Can we group the incompletes by common reasons?
 
 Yes, the incompletes can be grouped by two common reasons:
 
-1. Calibration difficulty (i.e., corrective lenses or make-up) applies to 4 of 8 incompletes
-2. Deciding to stop the task early (i.e., illness or difficulty with image content) applies to 2 of 8 incompletes
-
-Otherwise, 2 of 8 listed incompletes (CSN013, CSN031) have unknown reasons.
+1. Calibration difficulty (i.e., corrective lenses or make-up) applies to 5 of 7 incompletes
+2. Deciding to stop the task early (i.e., illness or difficulty with image content) applies to 2 of 7 incompletes

--- a/notebooks/summaries/incompletes.Rmd
+++ b/notebooks/summaries/incompletes.Rmd
@@ -1,0 +1,30 @@
+---
+title: "Summary Notebook: Incompletes"
+author: "Ari Dyckovsky"
+---
+
+```{r, notebook-options, include=FALSE}
+knitr::opts_chunk$set(
+  warning = FALSE,
+  strip.white = TRUE,
+  highlight = TRUE,
+  warning = FALSE,
+  message = FALSE
+)
+
+make_pretty_df <- function(df) {
+  if (isTRUE(getOption("knitr.in.progress"))) {
+    knitr::kable(df, "simple", format.args = list(big.mark = ",", scientific = FALSE))
+  } else {
+    df
+  }
+}
+```
+
+## Participants who did not complete the task
+
+### How many participants were incomplete?
+
+### What were the reasons participants did not complete the task?
+
+### Can we group the incompletes by common reasons?

--- a/notebooks/summaries/incompletes.md
+++ b/notebooks/summaries/incompletes.md
@@ -15,6 +15,34 @@ Ari Dyckovsky
 
 ### How many participants were incomplete?
 
+A total of **8 participants** of 57 recruited did *not complete* the
+task.
+
 ### What were the reasons participants did not complete the task?
 
+The reasons participants did not complete the task are briefly described
+in the following list by participant identifier:
+
+  - CSN003 had calibration issues (wore glasses)
+  - CSN014 had calibration issues (too much eye makeup)
+  - CSN024 stopped early due to illness
+  - CSN028 had calibration issues (difficult eye shape)
+  - CSN031 (no notes; Experimenter: LA)
+  - CSN046 stopped early due to graphic images
+  - CSN050 had calibration issues (wore contacts)
+
+Currently, we do not have enough information on:
+
+  - CSN013 may have completed the task
+
 ### Can we group the incompletes by common reasons?
+
+Yes, the incompletes can be grouped by two common reasons:
+
+1.  Calibration difficulty (i.e., corrective lenses or make-up) applies
+    to 4 of 8 incompletes
+2.  Deciding to stop the task early (i.e., illness or difficulty with
+    image content) applies to 2 of 8 incompletes
+
+Otherwise, 2 of 8 listed incompletes (CSN013, CSN031) have unknown
+reasons.

--- a/notebooks/summaries/incompletes.md
+++ b/notebooks/summaries/incompletes.md
@@ -1,0 +1,20 @@
+Summary Notebook: Incompletes
+================
+Ari Dyckovsky
+
+  - [Participants who did not complete the
+    task](#participants-who-did-not-complete-the-task)
+      - [How many participants were
+        incomplete?](#how-many-participants-were-incomplete)
+      - [What were the reasons participants did not complete the
+        task?](#what-were-the-reasons-participants-did-not-complete-the-task)
+      - [Can we group the incompletes by common
+        reasons?](#can-we-group-the-incompletes-by-common-reasons)
+
+## Participants who did not complete the task
+
+### How many participants were incomplete?
+
+### What were the reasons participants did not complete the task?
+
+### Can we group the incompletes by common reasons?

--- a/notebooks/summaries/incompletes.md
+++ b/notebooks/summaries/incompletes.md
@@ -15,7 +15,7 @@ Ari Dyckovsky
 
 ### How many participants were incomplete?
 
-A total of **8 participants** of 57 recruited did *not complete* the
+A total of **7 participants** of 57 recruited did *not complete* the
 task.
 
 ### What were the reasons participants did not complete the task?
@@ -27,22 +27,15 @@ in the following list by participant identifier:
   - CSN014 had calibration issues (too much eye makeup)
   - CSN024 stopped early due to illness
   - CSN028 had calibration issues (difficult eye shape)
-  - CSN031 (no notes; Experimenter: LA)
+  - CSN031 had calibration issues (wore glasses)
   - CSN046 stopped early due to graphic images
   - CSN050 had calibration issues (wore contacts)
-
-Currently, we do not have enough information on:
-
-  - CSN013 may have completed the task
 
 ### Can we group the incompletes by common reasons?
 
 Yes, the incompletes can be grouped by two common reasons:
 
 1.  Calibration difficulty (i.e., corrective lenses or make-up) applies
-    to 4 of 8 incompletes
+    to 5 of 7 incompletes
 2.  Deciding to stop the task early (i.e., illness or difficulty with
-    image content) applies to 2 of 8 incompletes
-
-Otherwise, 2 of 8 listed incompletes (CSN013, CSN031) have unknown
-reasons.
+    image content) applies to 2 of 7 incompletes


### PR DESCRIPTION
# Add participant incompletes summary

## Description

Created and populated an RMarkdown summary notebook for participant incompletes, as well as a knitted Markdown copy for GitHub-flavored Markdown presentation.

Resolves #5

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Additional context

This summary is subject to modification depending on the outcome of CSN013 completeness decision and CSN031 reason for an incomplete.
